### PR TITLE
feat: multi-sample ingest via anndata concatenation

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -1,7 +1,9 @@
-data_directory: "../data/output-XETG00171__0050702__Region_3__20250606__163112"
+samples:
+  - id: region_3
+    path: "../data/output-XETG00171__0050702__Region_3__20250606__163112"
+
 output_directory: "../output/output-XETG00171__0050702__Region_3__20250606__163112"
 annotation_model: "llama3.1:8b"
-condition: "prostate cancer"
 
 pipeline:
   minimum_counts: 200

--- a/main.py
+++ b/main.py
@@ -3,12 +3,11 @@ from __future__ import annotations
 import argparse
 from pathlib import Path
 
-from spatialdata_io import xenium
-
 from src import (
     analysis,
     annotation,
     colocalization,
+    ingest,
     io,
     plotting,
     preprocessing,
@@ -56,19 +55,13 @@ def load_configuration() -> Configuration:
     return configuration
 
 
-def _zarr_path(configuration: Configuration) -> Path:
-    """Return the path to the processed zarr store."""
+def _validate_anndata_exists(configuration: Configuration) -> None:
+    """Raise if the processed AnnData does not exist."""
 
-    return configuration.processed_data_directory / "processed.zarr"
-
-
-def _validate_zarr_exists(configuration: Configuration) -> None:
-    """Raise if the processed zarr does not exist."""
-
-    path = _zarr_path(configuration)
+    path = configuration.processed_data_directory / "processed.h5ad"
     if not path.exists():
         raise FileNotFoundError(
-            f"processed zarr not found at '{path}'. run the ingest stage first"
+            f"processed anndata not found at '{path}'. run the ingest stage first"
         )
 
 
@@ -77,11 +70,10 @@ def _validate_obs_column(
     column: str,
     stage_name: str,
 ) -> None:
-    """Raise if the zarr exists but is missing a required obs column."""
+    """Raise if the processed AnnData is missing a required obs column."""
 
-    _validate_zarr_exists(configuration)
-    spatial_data = io.read_spatialdata_zarr(configuration)
-    annotated_data = spatial_data["table"]
+    _validate_anndata_exists(configuration)
+    annotated_data = io.read_processed_anndata(configuration)
     if column not in annotated_data.obs.columns:
         raise ValueError(
             f"'{column}' not found in obs. run the upstream stages before {stage_name}"
@@ -93,49 +85,49 @@ def _validate_obsp_key(
     key: str,
     stage_name: str,
 ) -> None:
-    """Raise if the zarr exists but is missing a required obsp key."""
+    """Raise if the processed AnnData is missing a required obsp key."""
 
-    _validate_zarr_exists(configuration)
-    spatial_data = io.read_spatialdata_zarr(configuration)
-    annotated_data = spatial_data["table"]
+    _validate_anndata_exists(configuration)
+    annotated_data = io.read_processed_anndata(configuration)
     if key not in annotated_data.obsp:
         raise ValueError(
             f"'{key}' not found in obsp. run the upstream stages before {stage_name}"
         )
 
 
+def _validate_single_sample_until_library_key_support(
+    configuration: Configuration,
+    stage_name: str,
+) -> None:
+    """Block multi-sample runs from the spatial stages until #16 adds library_key handling."""
+
+    _validate_anndata_exists(configuration)
+    annotated_data = io.read_processed_anndata(configuration)
+    if "sample_id" in annotated_data.obs.columns:
+        number_of_samples = int(annotated_data.obs["sample_id"].nunique())
+        if number_of_samples > 1:
+            raise NotImplementedError(
+                f"{stage_name} does not yet support multi-sample runs "
+                f"(found {number_of_samples} samples). "
+                "Per-sample spatial graphs via squidpy's library_key land in issue #16."
+            )
+
+
 def run_ingest_stage(configuration: Configuration) -> None:
-    """Ingest raw Xenium output into a processed SpatialData zarr."""
+    """Ingest raw Xenium samples into a merged AnnData h5ad."""
 
     logger.info("stage: ingest")
-    if not configuration.raw_data_directory.exists():
-        raise FileNotFoundError(
-            f"raw data directory not found at '{configuration.raw_data_directory}'"
-        )
-
-    spatial_data = xenium(configuration.raw_data_directory)
-    if "morphology_focus" in spatial_data:
-        del spatial_data["morphology_focus"]
-        logger.debug("removed morphology_focus element from ingested spatialdata")
-
-    io.write_spatialdata_zarr(configuration, spatial_data)
+    ingest.run_ingest(configuration)
 
 
 def run_preprocess_stage(configuration: Configuration) -> None:
     """Run preprocessing and clustering steps on pre-ingested data."""
 
     logger.info("stage: preprocess and cluster")
-    _validate_zarr_exists(configuration)
-    spatial_data = io.read_spatialdata_zarr(configuration)
-    annotated_data = spatial_data["table"]
+    _validate_anndata_exists(configuration)
+    annotated_data = io.read_processed_anndata(configuration)
 
-    plotting.plot_cell_and_nucleus_boundaries(configuration, spatial_data)
-    plotting.plot_transcripts(
-        configuration,
-        spatial_data,
-        list(configuration.plots.genes_to_plot),
-        ["blue", "orange"],
-    )
+    # TODO(#16): per-sample spatial overlay plots (boundaries, transcripts) move to notebook helpers
 
     if "counts" in annotated_data.layers:
         annotated_data.X = annotated_data.layers["counts"].copy()
@@ -175,23 +167,20 @@ def run_preprocess_stage(configuration: Configuration) -> None:
     io.write_labels(configuration, annotated_data, "cluster")
     io.write_enriched_genes(configuration, enriched_gene_lists)
 
-    spatial_data["table"] = annotated_data
-    io.write_spatialdata_zarr(configuration, spatial_data)
+    io.write_processed_anndata(configuration, annotated_data)
 
 
 def run_annotate_stage(configuration: Configuration) -> None:
-    """Run LLM-driven cell-type annotation and persist updated zarr."""
+    """Run LLM-driven cell-type annotation and persist the updated AnnData."""
 
     logger.info("stage: annotate clusters")
     _validate_obs_column(configuration, "leiden", "annotate")
-    spatial_data = io.read_spatialdata_zarr(configuration)
-    annotated_data = spatial_data["table"]
+    annotated_data = io.read_processed_anndata(configuration)
 
     enriched_gene_lists = io.read_enriched_genes(configuration)
     cluster_annotations = annotation.annotate_clusters_with_llm(
         enriched_gene_lists,
         configuration.annotation_model,
-        configuration.condition,
         "marker_genes",
     )
     io.write_annotations(configuration, cluster_annotations, "cluster")
@@ -207,27 +196,18 @@ def run_annotate_stage(configuration: Configuration) -> None:
         )
     )
 
-    plotting.plot_umap_leiden(
-        configuration,
-        spatial_data,
-    )
-    plotting.plot_cluster_overlay(
-        configuration,
-        spatial_data,
-        cluster_key="cell_type",
-    )
+    # TODO(#16): UMAP-by-cluster and per-sample cluster overlay scatters
 
-    spatial_data["table"] = annotated_data
-    io.write_spatialdata_zarr(configuration, spatial_data)
+    io.write_processed_anndata(configuration, annotated_data)
 
 
 def run_domains_stage(configuration: Configuration) -> None:
-    """Run neighborhood analysis and persist updated zarr."""
+    """Run neighborhood analysis and persist the updated AnnData."""
 
     logger.info("stage: spatial domains")
     _validate_obs_column(configuration, "cell_type", "domains")
-    spatial_data = io.read_spatialdata_zarr(configuration)
-    annotated_data = spatial_data["table"]
+    _validate_single_sample_until_library_key_support(configuration, "domains")
+    annotated_data = io.read_processed_anndata(configuration)
 
     spatial_domains.compute_neighborhood_composition(
         annotated_data, configuration.pipeline.neighborhood_colocalization_radius
@@ -239,7 +219,6 @@ def run_domains_stage(configuration: Configuration) -> None:
     domain_annotations = annotation.annotate_clusters_with_llm(
         domain_signatures,
         configuration.annotation_model,
-        configuration.condition,
         "neighborhood_cell_types",
     )
 
@@ -257,14 +236,9 @@ def run_domains_stage(configuration: Configuration) -> None:
 
     io.write_labels(configuration, annotated_data, "domain")
 
-    plotting.plot_cluster_overlay(
-        configuration,
-        spatial_data,
-        cluster_key="spatial_domain_label",
-    )
+    # TODO(#16): per-sample spatial_domain_label overlay scatters
 
-    spatial_data["table"] = annotated_data
-    io.write_spatialdata_zarr(configuration, spatial_data)
+    io.write_processed_anndata(configuration, annotated_data)
 
 
 def run_colocalization_stage(configuration: Configuration) -> None:
@@ -273,8 +247,8 @@ def run_colocalization_stage(configuration: Configuration) -> None:
     logger.info("stage: colocalization")
     _validate_obs_column(configuration, "cell_type", "colocalization")
     _validate_obsp_key(configuration, "spatial_connectivities", "colocalization")
-    spatial_data = io.read_spatialdata_zarr(configuration)
-    annotated_data = spatial_data["table"]
+    _validate_single_sample_until_library_key_support(configuration, "colocalization")
+    annotated_data = io.read_processed_anndata(configuration)
 
     counts, row_proportions = colocalization.compute_observed_contact_matrices(
         annotated_data,

--- a/src/annotation.py
+++ b/src/annotation.py
@@ -9,11 +9,12 @@ from .logging import get_logger
 
 logger = get_logger(__name__)
 
+_CONDITION = "prostate cancer"
+
 
 def annotate_clusters_with_llm(
     annotation_evidence_by_cluster: dict[str, list[object]],
     model: str,
-    condition: str,
     evidence_type: str,
     host: str = "http://localhost:11434",
     temperature: float = 0.0,
@@ -41,7 +42,7 @@ def annotate_clusters_with_llm(
         "set of already-used labels and rewrite any candidate label that would "
         "collide before you return JSON. "
     )
-    condition_context = f"{condition} spatial transcriptomics"
+    condition_context = f"{_CONDITION} spatial transcriptomics"
     system_instruction = (
         f"You are a domain expert in {condition_context}. "
         "Use maximally specific labels (lineage + subtype + state), keep "
@@ -70,7 +71,6 @@ def annotate_clusters_with_llm(
                     "role": "user",
                     "content": _build_annotation_prompt(
                         annotation_evidence_by_cluster,
-                        condition,
                         evidence_type,
                     ),
                 },
@@ -102,7 +102,6 @@ def annotate_clusters_with_llm(
 
 def _build_annotation_prompt(
     annotation_evidence_by_cluster: dict[str, list[object]],
-    condition: str,
     evidence_type: str,
 ) -> str:
     """Build prompt with schema and per-cluster annotation evidence."""
@@ -116,7 +115,7 @@ def _build_annotation_prompt(
 
     if is_marker_mode:
         lines = [
-            f"Condition: {condition}.",
+            f"Condition: {_CONDITION}.",
             f"Annotate each cluster with one main cell type label from {evidence_label}.",
             "Be as specific as possible (lineage + subtype + functional state).",
             f"If clusters are similar, disambiguate using {support_phrase} states.",
@@ -137,7 +136,7 @@ def _build_annotation_prompt(
         ]
     else:
         lines = [
-            f"Condition: {condition}.",
+            f"Condition: {_CONDITION}.",
             "Annotate each spatial domain with one microenvironment label from neighboring cell-type composition.",
             "Do not output only a single raw cell type name; use niche/interface/transition-zone wording.",
             "Good label styles: 'Tumor-immune interface', 'Fibro-inflammatory stroma niche', 'Basal-luminal transition zone'.",

--- a/src/config.py
+++ b/src/config.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
@@ -9,6 +9,26 @@ import yaml
 from .logging import get_logger
 
 logger = get_logger(__name__)
+
+
+@dataclass
+class Sample:
+    """A single Xenium sample record loaded from config.yaml."""
+
+    id: str
+    path: Path
+
+    @classmethod
+    def from_dictionary(
+        cls: type[Sample],
+        data: dict[str, Any],
+    ) -> Sample:
+        """Create a Sample from a raw YAML record with id and path."""
+
+        return cls(
+            id=str(data["id"]),
+            path=Path(data["path"]).resolve(),
+        )
 
 
 @dataclass(frozen=True)
@@ -75,14 +95,13 @@ class PlotsConfiguration:
 class Configuration:
     """Top-level configuration loaded from YAML."""
 
-    raw_data_directory: Path | None = None
+    samples: list[Sample] = field(default_factory=list)
     output_directory: Path | None = None
     processed_data_directory: Path | None = None
     results_directory: Path | None = None
     figures_directory: Path | None = None
     logs_directory: Path | None = None
     annotation_model: str = "llama3.1:8b"
-    condition: str = "prostate cancer"
     pipeline: PipelineConfiguration | None = None
     plots: PlotsConfiguration | None = None
 
@@ -95,10 +114,7 @@ class Configuration:
         with configuration_path.open("r") as f:
             configuration = yaml.safe_load(f)
 
-        raw_data_directory = Path(configuration["data_directory"]).resolve()
         output_directory = Path(configuration["output_directory"]).resolve()
-
-        self.raw_data_directory = raw_data_directory
         self.output_directory = output_directory
         self.processed_data_directory = output_directory / "processed"
         self.results_directory = output_directory / "analysis"
@@ -107,12 +123,16 @@ class Configuration:
         self.annotation_model = str(
             configuration.get("annotation_model", self.annotation_model)
         )
-        self.condition = str(configuration.get("condition", self.condition))
+
+        self.samples = [
+            Sample.from_dictionary(record) for record in configuration["samples"]
+        ]
         self.pipeline = PipelineConfiguration.from_dictionary(configuration["pipeline"])
         self.plots = PlotsConfiguration.from_dictionary(configuration["plots"])
         logger.debug(
-            "loaded configuration from %s with output root %s",
+            "loaded configuration from %s with %s sample(s) and output root %s",
             configuration_path,
+            len(self.samples),
             self.output_directory,
         )
 

--- a/src/ingest.py
+++ b/src/ingest.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+import anndata as ad
+from spatialdata_io import xenium
+
+from . import io
+from .config import Configuration
+from .logging import get_logger
+
+logger = get_logger(__name__)
+
+
+def run_ingest(
+    configuration: Configuration,
+) -> None:
+    """Read each Xenium sample's table, concatenate into one AnnData, and write it out."""
+
+    logger.info("ingesting %s sample(s)", len(configuration.samples))
+    per_sample_tables = [
+        xenium(sample.path)["table"] for sample in configuration.samples
+    ]
+    sample_ids = [sample.id for sample in configuration.samples]
+    merged = ad.concat(
+        per_sample_tables,
+        keys=sample_ids,
+        label="sample_id",
+        index_unique="_",
+    )
+    merged.obs.index.name = None
+    io.write_processed_anndata(configuration, merged)

--- a/src/io.py
+++ b/src/io.py
@@ -1,13 +1,12 @@
 from __future__ import annotations
 
-from anndata import AnnData
 import json
 from pathlib import Path
-import shutil
 from typing import Any
 from uuid import uuid4
 
-from spatialdata import SpatialData, read_zarr
+import anndata as ad
+from anndata import AnnData
 
 from .config import Configuration
 from .logging import get_logger
@@ -15,35 +14,35 @@ from .logging import get_logger
 logger = get_logger(__name__)
 
 
-def read_spatialdata_zarr(
+def read_processed_anndata(
     configuration: Configuration,
-) -> SpatialData:
-    """Read processed zarr file from the processed data directory."""
+) -> AnnData:
+    """Read the merged processed AnnData from disk."""
 
-    path = configuration.processed_data_directory / "processed.zarr"
-    logger.debug("reading spatialdata zarr from %s", path)
-    return read_zarr(path)
+    path = configuration.processed_data_directory / "processed.h5ad"
+    logger.debug("reading processed anndata from %s", path)
+    return ad.read_h5ad(path)
 
 
-def write_spatialdata_zarr(
+def write_processed_anndata(
     configuration: Configuration,
-    spatial_data: SpatialData,
+    annotated_data: AnnData,
 ) -> None:
-    """Write processed spatial zarr using a simple temp-then-replace flow."""
+    """Write the merged processed AnnData using atomic temp-then-rename."""
 
-    target_path = configuration.processed_data_directory / "processed.zarr"
+    target_path = configuration.processed_data_directory / "processed.h5ad"
     temporary_path = target_path.parent / f".{target_path.name}.tmp-{uuid4().hex}"
 
-    spatial_data.write(temporary_path, overwrite=True)
+    annotated_data.write_h5ad(temporary_path)
 
     try:
         if target_path.exists():
-            shutil.rmtree(target_path)
+            target_path.unlink()
         temporary_path.rename(target_path)
-        logger.debug("wrote spatialdata zarr to %s", target_path)
+        logger.debug("wrote processed anndata to %s", target_path)
     finally:
         if temporary_path.exists():
-            shutil.rmtree(temporary_path)
+            temporary_path.unlink()
 
 
 def read_enriched_genes(

--- a/src/state.py
+++ b/src/state.py
@@ -23,11 +23,13 @@ def configuration_settings_snapshot(configuration: Configuration) -> dict[str, A
     pipeline = configuration.pipeline
     plots = configuration.plots
     snapshot = {
-        "raw_data_directory": str(configuration.raw_data_directory),
+        "samples": [
+            {"id": sample.id, "path": str(sample.path)}
+            for sample in configuration.samples
+        ],
         "output_directory": str(configuration.output_directory),
         "logs_directory": str(configuration.logs_directory),
         "annotation_model": configuration.annotation_model,
-        "condition": configuration.condition,
         "pipeline": {
             "minimum_counts": pipeline.minimum_counts,
             "maximum_counts_quantile": pipeline.maximum_counts_quantile,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,14 +7,15 @@ import numpy as np
 import pandas as pd
 import pytest
 from anndata import AnnData
-from geopandas import GeoDataFrame
 from scipy.sparse import csr_matrix
-from shapely.geometry import Polygon
-from spatialdata import SpatialData
-from spatialdata.models import ShapesModel, TableModel
 
 from src import logging as pipeline_logging
-from src.config import Configuration, PipelineConfiguration, PlotsConfiguration
+from src.config import (
+    Configuration,
+    PipelineConfiguration,
+    PlotsConfiguration,
+    Sample,
+)
 
 
 @pytest.fixture(autouse=True)
@@ -38,14 +39,13 @@ def configuration(tmp_path: Path) -> Configuration:
     """Build a Configuration whose directories all live under tmp_path."""
 
     config = Configuration(
-        raw_data_directory=tmp_path / "raw",
+        samples=[Sample(id="sample_a", path=tmp_path / "raw" / "sample_a")],
         output_directory=tmp_path / "output",
         processed_data_directory=tmp_path / "output" / "processed",
         results_directory=tmp_path / "output" / "analysis",
         figures_directory=tmp_path / "output" / "figures",
         logs_directory=tmp_path / "output" / "logs",
         annotation_model="llama3.1:8b",
-        condition="prostate cancer",
         pipeline=PipelineConfiguration(
             minimum_counts=5,
             maximum_counts_quantile=0.99,
@@ -70,11 +70,13 @@ def build_synthetic_adata(
     n_per_type: int = 40,
     n_genes: int = 24,
     n_types: int = 3,
+    gene_prefix: str = "gene",
+    coord_offset: tuple[float, float] = (0.0, 0.0),
 ) -> AnnData:
     """Synthetic AnnData with distinct cell-type marker blocks and clustered coordinates."""
 
     rng = np.random.default_rng(seed)
-    gene_names = [f"gene_{i}" for i in range(n_genes)]
+    gene_names = [f"{gene_prefix}_{i}" for i in range(n_genes)]
     block_size = n_genes // n_types
 
     count_blocks = []
@@ -99,7 +101,7 @@ def build_synthetic_adata(
             centers[i] + rng.normal(0.0, 8.0, size=(n_per_type, 2))
             for i in range(n_types)
         ]
-    )
+    ) + np.array(coord_offset)
 
     cell_types = np.concatenate(
         [np.full(n_per_type, f"type_{i}", dtype=object) for i in range(n_types)]
@@ -109,10 +111,9 @@ def build_synthetic_adata(
         {
             "cell_id": cell_ids,
             "cell_type": pd.Categorical(cell_types),
-            "region": pd.Categorical(["cell_boundaries"] * n_obs),
             "total_counts": counts.sum(axis=1),
         },
-        index=pd.Index(cell_ids, name="cell_id"),
+        index=pd.Index(cell_ids),
     )
     var = pd.DataFrame(index=pd.Index(gene_names, name="gene_id"))
 
@@ -124,47 +125,6 @@ def build_synthetic_adata(
 
 @pytest.fixture
 def tiny_adata() -> AnnData:
-    """Synthetic AnnData for tests that do not need a SpatialData wrapper."""
+    """Synthetic AnnData used by most tests."""
 
     return build_synthetic_adata()
-
-
-def _cell_boundary_polygons(coords: np.ndarray, cell_ids: list[str]) -> GeoDataFrame:
-    """Build a GeoDataFrame of square cell boundaries centered on spatial coords."""
-
-    side = 2.0
-    polygons = [
-        Polygon(
-            [
-                (x - side, y - side),
-                (x + side, y - side),
-                (x + side, y + side),
-                (x - side, y + side),
-            ]
-        )
-        for x, y in coords
-    ]
-    gdf = GeoDataFrame(
-        {"geometry": polygons},
-        index=pd.Index(cell_ids, name="cell_id"),
-    )
-    return ShapesModel.parse(gdf)
-
-
-@pytest.fixture
-def tiny_spatialdata(tiny_adata: AnnData) -> SpatialData:
-    """Minimal SpatialData wrapping tiny_adata with cell_boundaries shapes."""
-
-    cell_ids = tiny_adata.obs["cell_id"].tolist()
-    cell_boundaries = _cell_boundary_polygons(tiny_adata.obsm["spatial"], cell_ids)
-
-    table = TableModel.parse(
-        tiny_adata.copy(),
-        region="cell_boundaries",
-        region_key="region",
-        instance_key="cell_id",
-    )
-    return SpatialData(
-        shapes={"cell_boundaries": cell_boundaries},
-        tables={"table": table},
-    )

--- a/tests/test_annotation.py
+++ b/tests/test_annotation.py
@@ -25,11 +25,10 @@ def test_annotation_schema_shape() -> None:
 
 
 def test_build_annotation_prompt_marker_mode_includes_evidence() -> None:
-    """Marker-mode prompt lists clusters and their formatted evidence items."""
+    """Marker-mode prompt lists clusters, formatted evidence, and the hardcoded condition."""
 
     prompt = annotation._build_annotation_prompt(
         {"0": ["KRT8", "EPCAM"], "1": ["CD3D"]},
-        condition="prostate cancer",
         evidence_type="marker_genes",
     )
     assert "Condition: prostate cancer." in prompt
@@ -43,7 +42,6 @@ def test_build_annotation_prompt_neighborhood_mode_uses_niche_wording() -> None:
 
     prompt = annotation._build_annotation_prompt(
         {"0": [("Tumor", 0.6), ("Stroma", 0.4)]},
-        condition="prostate cancer",
         evidence_type="neighborhood_cell_types",
     )
     assert "niche/interface" in prompt
@@ -99,7 +97,6 @@ def test_annotate_clusters_with_llm_parses_response() -> None:
         result = annotation.annotate_clusters_with_llm(
             {"0": ["KRT8"], "1": ["CD3D"]},
             model="llama3.1:8b",
-            condition="prostate cancer",
             evidence_type="marker_genes",
         )
 
@@ -119,7 +116,6 @@ def test_annotate_clusters_with_llm_raises_on_network_error() -> None:
             annotation.annotate_clusters_with_llm(
                 {"0": ["KRT8"]},
                 model="llama3.1:8b",
-                condition="prostate cancer",
                 evidence_type="marker_genes",
             )
 
@@ -136,7 +132,6 @@ def test_annotate_clusters_with_llm_raises_on_invalid_json() -> None:
             annotation.annotate_clusters_with_llm(
                 {"0": ["KRT8"]},
                 model="llama3.1:8b",
-                condition="prostate cancer",
                 evidence_type="marker_genes",
             )
 
@@ -166,7 +161,6 @@ def test_annotate_clusters_with_llm_sends_expected_payload() -> None:
         annotation.annotate_clusters_with_llm(
             {"0": ["KRT8"]},
             model="llama3.1:8b",
-            condition="prostate cancer",
             evidence_type="marker_genes",
         )
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -5,15 +5,14 @@ from pathlib import Path
 import pytest
 import yaml
 
-from src.config import Configuration, PipelineConfiguration, PlotsConfiguration
+from src.config import Configuration, PipelineConfiguration, PlotsConfiguration, Sample
 
 
 def _base_config_dict(raw: Path, output: Path) -> dict:
     return {
-        "data_directory": str(raw),
+        "samples": [{"id": "sample_a", "path": str(raw / "sample_a")}],
         "output_directory": str(output),
         "annotation_model": "llama3.1:8b",
-        "condition": "prostate cancer",
         "pipeline": {
             "minimum_counts": 10,
             "maximum_counts_quantile": 0.99,
@@ -38,7 +37,7 @@ def _write_config(tmp_path: Path, payload: dict) -> Path:
 
 
 def test_load_from_yaml_populates_all_fields(tmp_path: Path) -> None:
-    """load_from_yaml fills directories and nested configs from YAML."""
+    """load_from_yaml fills directories, samples, and nested configs from YAML."""
 
     config_path = _write_config(
         tmp_path, _base_config_dict(tmp_path / "raw", tmp_path / "output")
@@ -47,8 +46,8 @@ def test_load_from_yaml_populates_all_fields(tmp_path: Path) -> None:
     configuration.load_from_yaml(config_path)
 
     assert configuration.annotation_model == "llama3.1:8b"
-    assert configuration.condition == "prostate cancer"
-    assert configuration.raw_data_directory == (tmp_path / "raw").resolve()
+    assert [sample.id for sample in configuration.samples] == ["sample_a"]
+    assert configuration.samples[0].path == (tmp_path / "raw" / "sample_a").resolve()
     assert configuration.output_directory == (tmp_path / "output").resolve()
     assert (
         configuration.processed_data_directory
@@ -79,17 +78,15 @@ def test_plots_genes_are_sorted(tmp_path: Path) -> None:
 
 
 def test_defaults_used_when_optional_keys_omitted(tmp_path: Path) -> None:
-    """Missing optional keys fall back to the Configuration defaults."""
+    """Missing optional keys fall back to Configuration defaults."""
 
     payload = _base_config_dict(tmp_path / "raw", tmp_path / "output")
     payload.pop("annotation_model")
-    payload.pop("condition")
     config_path = _write_config(tmp_path, payload)
 
     configuration = Configuration()
     configuration.load_from_yaml(config_path)
     assert configuration.annotation_model == "llama3.1:8b"
-    assert configuration.condition == "prostate cancer"
 
 
 def test_create_directories_makes_all_outputs(tmp_path: Path) -> None:
@@ -109,6 +106,35 @@ def test_create_directories_makes_all_outputs(tmp_path: Path) -> None:
         configuration.logs_directory,
     ):
         assert directory.is_dir()
+
+
+def test_multiple_samples_parsed_in_order(tmp_path: Path) -> None:
+    """Multiple sample records are loaded preserving the order given in YAML."""
+
+    payload = _base_config_dict(tmp_path / "raw", tmp_path / "output")
+    payload["samples"] = [
+        {"id": "patient_001", "path": str(tmp_path / "raw" / "p001")},
+        {"id": "patient_002", "path": str(tmp_path / "raw" / "p002")},
+        {"id": "patient_003", "path": str(tmp_path / "raw" / "p003")},
+    ]
+    config_path = _write_config(tmp_path, payload)
+
+    configuration = Configuration()
+    configuration.load_from_yaml(config_path)
+
+    assert [sample.id for sample in configuration.samples] == [
+        "patient_001",
+        "patient_002",
+        "patient_003",
+    ]
+
+
+def test_sample_from_dictionary_parses_id_and_path(tmp_path: Path) -> None:
+    """Sample.from_dictionary reads id and path fields."""
+
+    sample = Sample.from_dictionary({"id": "a", "path": str(tmp_path / "a")})
+    assert sample.id == "a"
+    assert sample.path == (tmp_path / "a").resolve()
 
 
 def test_pipeline_configuration_casts_numeric_types() -> None:

--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -1,0 +1,145 @@
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from anndata import AnnData
+
+from src import io
+from src.config import Configuration, PipelineConfiguration, PlotsConfiguration, Sample
+from src.ingest import run_ingest
+
+from .conftest import build_synthetic_adata
+
+
+@pytest.fixture
+def multi_sample_configuration(tmp_path: Path) -> Configuration:
+    """Configuration with two sample records pointing at placeholder paths."""
+
+    configuration = Configuration(
+        samples=[
+            Sample(id="patient_001", path=tmp_path / "raw" / "patient_001"),
+            Sample(id="patient_002", path=tmp_path / "raw" / "patient_002"),
+        ],
+        output_directory=tmp_path / "output",
+        processed_data_directory=tmp_path / "output" / "processed",
+        results_directory=tmp_path / "output" / "analysis",
+        figures_directory=tmp_path / "output" / "figures",
+        logs_directory=tmp_path / "output" / "logs",
+        pipeline=PipelineConfiguration(
+            minimum_counts=1,
+            maximum_counts_quantile=0.99,
+            minimum_cells=1,
+            pca_n_components=2,
+            neighborhood_colocalization_radius=1.0,
+            colocalization_number_of_permutations=1,
+            colocalization_minimum_cells=1,
+            domain_n_clusters=2,
+            rank_top_n=1,
+            minimum_logarithm_fold_change=0.0,
+            maximum_adjusted_p_value=1.0,
+        ),
+        plots=PlotsConfiguration(genes_to_plot=()),
+    )
+    configuration.create_directories()
+    return configuration
+
+
+def _mock_xenium_from_samples(
+    samples_by_id: dict[str, AnnData],
+):
+    """Return a side_effect callable for patching xenium() that returns AnnData wrapped in a table-like dict."""
+
+    def fake_xenium(path):
+        sample_id = Path(path).name
+        return {"table": samples_by_id[sample_id]}
+
+    return fake_xenium
+
+
+def test_run_ingest_merges_two_samples_into_one_anndata(
+    multi_sample_configuration: Configuration,
+) -> None:
+    """run_ingest concatenates per-sample tables and writes a merged processed.h5ad."""
+
+    per_sample = {
+        "patient_001": build_synthetic_adata(seed=0),
+        "patient_002": build_synthetic_adata(seed=1, coord_offset=(1000.0, 0.0)),
+    }
+
+    with patch("src.ingest.xenium", side_effect=_mock_xenium_from_samples(per_sample)):
+        run_ingest(multi_sample_configuration)
+
+    merged = io.read_processed_anndata(multi_sample_configuration)
+
+    assert (
+        merged.n_obs
+        == per_sample["patient_001"].n_obs + per_sample["patient_002"].n_obs
+    )
+    assert "sample_id" in merged.obs.columns
+    assert set(merged.obs["sample_id"].astype(str).unique()) == {
+        "patient_001",
+        "patient_002",
+    }
+
+
+def test_run_ingest_makes_obs_names_unique_across_samples(
+    multi_sample_configuration: Configuration,
+) -> None:
+    """obs_names in the merged AnnData are globally unique even when per-sample cell_ids collide."""
+
+    per_sample = {
+        "patient_001": build_synthetic_adata(seed=0),
+        "patient_002": build_synthetic_adata(seed=1),
+    }
+
+    with patch("src.ingest.xenium", side_effect=_mock_xenium_from_samples(per_sample)):
+        run_ingest(multi_sample_configuration)
+
+    merged = io.read_processed_anndata(multi_sample_configuration)
+
+    assert len(set(merged.obs_names)) == merged.n_obs
+
+
+def test_run_ingest_preserves_original_cell_id(
+    multi_sample_configuration: Configuration,
+) -> None:
+    """obs['cell_id'] retains each sample's original per-sample cell id for Explorer export."""
+
+    per_sample = {
+        "patient_001": build_synthetic_adata(seed=0, n_per_type=5),
+        "patient_002": build_synthetic_adata(seed=1, n_per_type=5),
+    }
+
+    with patch("src.ingest.xenium", side_effect=_mock_xenium_from_samples(per_sample)):
+        run_ingest(multi_sample_configuration)
+
+    merged = io.read_processed_anndata(multi_sample_configuration)
+    original_ids = set(merged.obs["cell_id"].astype(str).unique())
+    assert original_ids == {f"cell_{i:04d}" for i in range(15)}
+
+
+def test_run_ingest_single_sample_writes_anndata(
+    configuration: Configuration,
+    tiny_adata: AnnData,
+) -> None:
+    """Single-sample run writes an AnnData with a sample_id column equal to that sample's id."""
+
+    per_sample = {"sample_a": tiny_adata}
+
+    with patch("src.ingest.xenium", side_effect=_mock_xenium_from_samples(per_sample)):
+        run_ingest(configuration)
+
+    merged = io.read_processed_anndata(configuration)
+    assert merged.n_obs == tiny_adata.n_obs
+    assert (merged.obs["sample_id"].astype(str) == "sample_a").all()
+
+
+def test_run_ingest_raises_on_missing_sample_path(
+    multi_sample_configuration: Configuration,
+) -> None:
+    """A non-existent sample path surfaces as an error from the underlying xenium loader."""
+
+    with pytest.raises(Exception):
+        run_ingest(multi_sample_configuration)

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -4,43 +4,43 @@ import json
 from pathlib import Path
 
 import pandas as pd
-from spatialdata import SpatialData
+from anndata import AnnData
 
 from src import io
 from src.config import Configuration
 
 
-def test_spatialdata_zarr_round_trip(
+def test_processed_anndata_round_trip(
     configuration: Configuration,
-    tiny_spatialdata: SpatialData,
+    tiny_adata: AnnData,
 ) -> None:
-    """write_spatialdata_zarr + read_spatialdata_zarr preserves the table."""
+    """write_processed_anndata + read_processed_anndata preserves the AnnData."""
 
-    io.write_spatialdata_zarr(configuration, tiny_spatialdata)
-    round_tripped = io.read_spatialdata_zarr(configuration)
+    io.write_processed_anndata(configuration, tiny_adata)
+    round_tripped = io.read_processed_anndata(configuration)
 
-    zarr_path = configuration.processed_data_directory / "processed.zarr"
-    assert zarr_path.exists()
-    assert round_tripped["table"].n_obs == tiny_spatialdata["table"].n_obs
-    assert round_tripped["table"].n_vars == tiny_spatialdata["table"].n_vars
-    assert "cell_boundaries" in round_tripped.shapes
+    h5ad_path = configuration.processed_data_directory / "processed.h5ad"
+    assert h5ad_path.exists()
+    assert round_tripped.n_obs == tiny_adata.n_obs
+    assert round_tripped.n_vars == tiny_adata.n_vars
+    assert list(round_tripped.obs.columns) == list(tiny_adata.obs.columns)
 
 
-def test_write_spatialdata_zarr_overwrites_previous_zarr(
+def test_write_processed_anndata_overwrites_previous_file(
     configuration: Configuration,
-    tiny_spatialdata: SpatialData,
+    tiny_adata: AnnData,
 ) -> None:
-    """Re-writing replaces the prior zarr without leaving a stale temp directory."""
+    """Re-writing replaces the prior h5ad without leaving a stale temp file."""
 
-    io.write_spatialdata_zarr(configuration, tiny_spatialdata)
-    io.write_spatialdata_zarr(configuration, tiny_spatialdata)
+    io.write_processed_anndata(configuration, tiny_adata)
+    io.write_processed_anndata(configuration, tiny_adata)
 
     processed_dir = configuration.processed_data_directory
     tmp_entries = [
         p for p in processed_dir.iterdir() if p.name.startswith(".processed")
     ]
     assert tmp_entries == []
-    assert (processed_dir / "processed.zarr").exists()
+    assert (processed_dir / "processed.h5ad").exists()
 
 
 def test_enriched_genes_round_trip(configuration: Configuration) -> None:
@@ -71,7 +71,7 @@ def test_write_annotations_creates_expected_files(configuration: Configuration) 
 
 def test_write_labels_cluster_mode_writes_csv_with_cell_id(
     configuration: Configuration,
-    tiny_adata,
+    tiny_adata: AnnData,
 ) -> None:
     """write_labels produces leiden_clusters.csv with the cell_id and group columns."""
 
@@ -89,7 +89,7 @@ def test_write_labels_cluster_mode_writes_csv_with_cell_id(
 
 def test_write_labels_domain_mode_writes_csv_at_expected_path(
     configuration: Configuration,
-    tiny_adata,
+    tiny_adata: AnnData,
 ) -> None:
     """write_labels in domain mode writes spatial_domain_labels.csv."""
 

--- a/tests/test_logging_and_state.py
+++ b/tests/test_logging_and_state.py
@@ -70,7 +70,6 @@ def test_configuration_settings_snapshot_round_trips_key_values(
     snapshot = state.configuration_settings_snapshot(configuration)
 
     assert snapshot["annotation_model"] == configuration.annotation_model
-    assert snapshot["condition"] == configuration.condition
     assert snapshot["pipeline"]["pca_n_components"] == (
         configuration.pipeline.pca_n_components
     )
@@ -78,3 +77,15 @@ def test_configuration_settings_snapshot_round_trips_key_values(
         configuration.pipeline.colocalization_number_of_permutations
     )
     assert snapshot["plots"]["genes_to_plot"] == list(configuration.plots.genes_to_plot)
+
+
+def test_configuration_settings_snapshot_includes_samples(
+    configuration: Configuration,
+) -> None:
+    """The snapshot lists each sample's id and path."""
+
+    snapshot = state.configuration_settings_snapshot(configuration)
+
+    assert snapshot["samples"] == [
+        {"id": sample.id, "path": str(sample.path)} for sample in configuration.samples
+    ]

--- a/tests/test_main_guards.py
+++ b/tests/test_main_guards.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+import pytest
+from anndata import AnnData
+
+import main
+from src import io
+from src.config import Configuration
+
+
+def _write_adata_with_sample_ids(
+    configuration: Configuration,
+    adata: AnnData,
+    sample_ids: list[str],
+) -> None:
+    """Stamp a sample_id column on the AnnData and write it as the processed artifact."""
+
+    assert len(sample_ids) == adata.n_obs
+    adata.obs["sample_id"] = sample_ids
+    io.write_processed_anndata(configuration, adata)
+
+
+def test_domains_stage_raises_on_multi_sample_data(
+    configuration: Configuration,
+    tiny_adata: AnnData,
+) -> None:
+    """run_domains_stage refuses multi-sample runs until per-sample spatial graphs land."""
+
+    sample_ids = ["patient_001"] * (tiny_adata.n_obs // 2) + ["patient_002"] * (
+        tiny_adata.n_obs - tiny_adata.n_obs // 2
+    )
+    tiny_adata.obs["cell_type"] = tiny_adata.obs["cell_type"].astype(str)
+    _write_adata_with_sample_ids(configuration, tiny_adata, sample_ids)
+
+    with pytest.raises(NotImplementedError, match="multi-sample runs"):
+        main.run_domains_stage(configuration)
+
+
+def test_colocalization_stage_raises_on_multi_sample_data(
+    configuration: Configuration,
+    tiny_adata: AnnData,
+) -> None:
+    """run_colocalization_stage refuses multi-sample runs until per-sample spatial graphs land."""
+
+    import squidpy as sq
+
+    sq.gr.spatial_neighbors(
+        tiny_adata, radius=30.0, coord_type="generic", delaunay=True
+    )
+    sample_ids = ["patient_001"] * (tiny_adata.n_obs // 2) + ["patient_002"] * (
+        tiny_adata.n_obs - tiny_adata.n_obs // 2
+    )
+    tiny_adata.obs["cell_type"] = tiny_adata.obs["cell_type"].astype(str)
+    _write_adata_with_sample_ids(configuration, tiny_adata, sample_ids)
+
+    with pytest.raises(NotImplementedError, match="multi-sample runs"):
+        main.run_colocalization_stage(configuration)
+
+
+def test_guard_passes_for_single_sample_data(
+    configuration: Configuration,
+    tiny_adata: AnnData,
+) -> None:
+    """The guard is a no-op when only one sample_id is present."""
+
+    sample_ids = ["patient_001"] * tiny_adata.n_obs
+    _write_adata_with_sample_ids(configuration, tiny_adata, sample_ids)
+
+    main._validate_single_sample_until_library_key_support(configuration, "domains")

--- a/tests/test_plotting.py
+++ b/tests/test_plotting.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import scanpy as sc
 from anndata import AnnData
-from spatialdata import SpatialData
 
 from src import analysis, colocalization, plotting
 from src.config import Configuration
@@ -14,22 +13,6 @@ def _assert_nonempty_file(path) -> None:
 
     assert path.exists(), f"expected figure at {path}"
     assert path.stat().st_size > 0, f"figure at {path} is empty"
-
-
-def test_plot_cell_and_nucleus_boundaries_missing_element_is_skipped(
-    configuration: Configuration,
-    tiny_spatialdata: SpatialData,
-) -> None:
-    """The fixture lacks nucleus_boundaries, so this smoke test only covers cell_boundaries path."""
-
-    # nucleus_boundaries is optional in the fixture; we patch it in by aliasing cell_boundaries.
-    tiny_spatialdata.shapes["nucleus_boundaries"] = tiny_spatialdata.shapes[
-        "cell_boundaries"
-    ]
-    plotting.plot_cell_and_nucleus_boundaries(configuration, tiny_spatialdata)
-
-    output_path = configuration.figures_directory / "xenium_cell_nucleus_boundaries.png"
-    _assert_nonempty_file(output_path)
 
 
 def test_plot_qc_histogram_writes_figure(
@@ -47,37 +30,6 @@ def test_plot_qc_histogram_writes_figure(
 
     output_path = configuration.figures_directory / "xenium_transcripts_per_cell.png"
     _assert_nonempty_file(output_path)
-
-
-def test_plot_umap_leiden_writes_figure(
-    configuration: Configuration,
-    tiny_spatialdata: SpatialData,
-) -> None:
-    """plot_umap_leiden writes the UMAP figure after clustering and UMAP."""
-
-    adata = tiny_spatialdata["table"]
-    sc.pp.calculate_qc_metrics(adata, inplace=True, percent_top=None, log1p=False)
-    normalize_and_scale(adata)
-    analysis.run_clustering(adata, pca_n_components=5)
-    analysis.run_umap(adata)
-    adata.obs["cell_type"] = adata.obs["leiden"].astype(str)
-
-    plotting.plot_umap_leiden(configuration, tiny_spatialdata)
-    _assert_nonempty_file(configuration.figures_directory / "umap_leiden.png")
-
-
-def test_plot_cluster_overlay_writes_figure(
-    configuration: Configuration,
-    tiny_spatialdata: SpatialData,
-) -> None:
-    """plot_cluster_overlay writes a PNG named after the cluster key."""
-
-    plotting.plot_cluster_overlay(
-        configuration, tiny_spatialdata, cluster_key="cell_type"
-    )
-    _assert_nonempty_file(
-        configuration.figures_directory / "xenium_cell_type_overlay.png"
-    )
 
 
 def test_plot_rank_genes_dotplot_writes_figure(


### PR DESCRIPTION
## Summary

Replaces the single-sample `processed.zarr` pipeline artifact with a merged `processed.h5ad` produced by concatenating each sample's AnnData table via `ad.concat(keys, label, index_unique)`. SpatialData elements (shapes, points, coord systems) were only used by three plotting functions and never by the analysis, so dropping them shrinks ingest from ~170 lines to ~12 and sidesteps the `instance_key` / element-collision issues the earlier merged-SpatialData approach was hitting.

## Changes

- **`src/config.py`** — new `Sample` dataclass (`id`, `path`); `Configuration.samples: list[Sample]`; drops `raw_data_directory` and `condition`.
- **`src/ingest.py`** *(new)* — 12-line `run_ingest`: per-sample `xenium(path)["table"]`, `ad.concat(keys=sample_ids, label="sample_id", index_unique="_")`, write h5ad.
- **`src/io.py`** — `read_processed_anndata` / `write_processed_anndata` with atomic temp-then-rename; old SpatialData zarr helpers removed.
- **`src/annotation.py`** — drops the `condition` parameter from `annotate_clusters_with_llm` and the prompt builder; hardcodes `_CONDITION = "prostate cancer"`.
- **`src/state.py`** — snapshot includes `samples: [{id, path}]`; drops `raw_data_directory` and `condition`.
- **`main.py`** — delegates ingest to `src/ingest.py`; all stages read/write AnnData via the new IO; SpatialData-dependent plot calls removed with `TODO(#16)` markers; new `_validate_single_sample_until_library_key_support` guard blocks `run_domains_stage` and `run_colocalization_stage` from silently corrupting multi-sample runs until #16 adds squidpy `library_key` handling.
- **`config.yaml`** — `samples: [{id, path}]` shape; `condition` removed.
- **`tests/conftest.py`** — drops the `tiny_spatialdata` fixture and SpatialData / GeoPandas / Shapely imports.
- **`tests/test_ingest.py`** *(new, 5 tests)* — merge, unique `obs_names`, preserved per-sample `cell_id`, single-sample path, missing-path raises.
- **`tests/test_main_guards.py`** *(new, 3 tests)* — multi-sample domains / colocalization raise; single-sample is a no-op.
- **Updated existing tests** for the new shape; three plotting tests that depended on `tiny_spatialdata` are removed and will be re-added with centroid-scatter implementations in #16.

## Testing

```bash
uv run pytest
# 61 passed
```

The working `config.yaml` still points at a single sample, so end-to-end behavior is unchanged on that path. Multi-sample runs currently reach ingest + preprocess + annotate correctly; domains and colocalization will raise `NotImplementedError` pointing to #16, preventing silent cross-sample spatial-graph corruption in the interim.

## Closes

Closes #14.