### PR TITLE
feat: harmony batch correction and per-sample mad qc

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -1,13 +1,11 @@
 samples:
-  - id: region_3
-    path: "../data/output-XETG00171__0050702__Region_3__20250606__163112"
+  - id: region_2
+    path: "../data/output-XETG00171__0050702__Region_2__20250606__163112"
 
-output_directory: "../output/output-XETG00171__0050702__Region_3__20250606__163112"
+output_directory: "../output"
 annotation_model: "llama3.1:8b"
 
 pipeline:
-  minimum_counts: 200
-  maximum_counts_quantile: 0.99
   minimum_cells: 100
   pca_n_components: 30
   neighborhood_colocalization_radius: 50.0

--- a/main.py
+++ b/main.py
@@ -134,19 +134,9 @@ def run_preprocess_stage(configuration: Configuration) -> None:
     else:
         annotated_data.layers["counts"] = annotated_data.X.copy()
 
-    plotting.plot_qc_histogram(
-        configuration,
-        annotated_data,
-        [
-            configuration.pipeline.minimum_counts,
-            configuration.pipeline.maximum_counts_quantile,
-        ],
-        ["crimson", "goldenrod"],
-    )
+    # TODO(#16): faceted per-sample QC histogram with MAD cutoffs replaces the legacy global histogram
     preprocessing.filter_cells_and_genes(
         annotated_data,
-        configuration.pipeline.minimum_counts,
-        configuration.pipeline.maximum_counts_quantile,
         configuration.pipeline.minimum_cells,
     )
     preprocessing.normalize_and_scale(annotated_data)
@@ -154,7 +144,7 @@ def run_preprocess_stage(configuration: Configuration) -> None:
         annotated_data,
         configuration.pipeline.pca_n_components,
     )
-    analysis.run_umap(annotated_data)
+    plotting.plot_harmony_diagnostic(configuration, annotated_data)
     analysis.rank_genes(annotated_data)
     enriched_gene_lists = analysis.compute_enriched_genes(
         annotated_data,
@@ -196,7 +186,14 @@ def run_annotate_stage(configuration: Configuration) -> None:
         )
     )
 
-    # TODO(#16): UMAP-by-cluster and per-sample cluster overlay scatters
+    plotting.plot_umap_leiden(configuration, annotated_data)
+    for sample in configuration.samples:
+        plotting.plot_cluster_overlay(
+            configuration,
+            annotated_data,
+            cluster_key="cell_type",
+            sample_id=sample.id,
+        )
 
     io.write_processed_anndata(configuration, annotated_data)
 
@@ -236,7 +233,13 @@ def run_domains_stage(configuration: Configuration) -> None:
 
     io.write_labels(configuration, annotated_data, "domain")
 
-    # TODO(#16): per-sample spatial_domain_label overlay scatters
+    for sample in configuration.samples:
+        plotting.plot_cluster_overlay(
+            configuration,
+            annotated_data,
+            cluster_key="spatial_domain_label",
+            sample_id=sample.id,
+        )
 
     io.write_processed_anndata(configuration, annotated_data)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,6 +5,7 @@ description = "Add your description here"
 readme = "README.md"
 requires-python = ">=3.13"
 dependencies = [
+    "harmonypy==0.0.10",
     "igraph>=1.0.0",
     "scanpy>=1.11,<1.12",
     "scikit-misc>=0.5.2",

--- a/src/analysis.py
+++ b/src/analysis.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from anndata import AnnData
 import pandas as pd
 import scanpy as sc
+import scanpy.external as sce
 
 from .logging import get_logger
 
@@ -13,11 +14,34 @@ def run_clustering(
     annotated_data: AnnData,
     pca_n_components: int,
 ) -> None:
-    """Run clustering on the annotated data."""
+    """Run PCA, optional Harmony batch correction, neighbors, UMAP, and Leiden."""
 
-    logger.debug("running PCA/neighbors/leiden with %s components", pca_n_components)
+    logger.debug("running PCA with %s components", pca_n_components)
     sc.pp.pca(annotated_data, n_comps=pca_n_components)
-    sc.pp.neighbors(annotated_data, metric="cosine")
+
+    if (
+        "sample_id" in annotated_data.obs.columns
+        and annotated_data.obs["sample_id"].nunique() > 1
+    ):
+        logger.info(
+            "running multi-sample clustering with Harmony on %s samples",
+            annotated_data.obs["sample_id"].nunique(),
+        )
+        sc.pp.neighbors(annotated_data, use_rep="X_pca", metric="cosine")
+        sc.tl.umap(annotated_data)
+        annotated_data.obsm["X_umap_uncorrected"] = annotated_data.obsm["X_umap"].copy()
+
+        # `sample_id` is the only valid batch key here. Do not add biologically
+        # meaningful groupings (e.g. `condition`) — Harmony scrubs variance on its
+        # batch key, and scrubbing biological signal would defeat the analysis.
+        sce.pp.harmony_integrate(annotated_data, key="sample_id")
+
+        sc.pp.neighbors(annotated_data, use_rep="X_pca_harmony", metric="cosine")
+        sc.tl.umap(annotated_data)
+    else:
+        sc.pp.neighbors(annotated_data, use_rep="X_pca", metric="cosine")
+        sc.tl.umap(annotated_data)
+
     sc.tl.leiden(
         annotated_data,
         resolution=0.5,
@@ -27,16 +51,6 @@ def run_clustering(
         "found %s leiden clusters",
         annotated_data.obs["leiden"].nunique(),
     )
-
-
-def run_umap(
-    annotated_data: AnnData,
-) -> None:
-    """Run UMAP on the annotated data."""
-
-    logger.debug("running UMAP embedding")
-    sc.tl.umap(annotated_data)
-    logger.debug("UMAP embedding complete")
 
 
 def rank_genes(

--- a/src/config.py
+++ b/src/config.py
@@ -35,8 +35,6 @@ class Sample:
 class PipelineConfiguration:
     """Numeric parameters for the analysis pipeline."""
 
-    minimum_counts: int
-    maximum_counts_quantile: float
     minimum_cells: int
     pca_n_components: int
     neighborhood_colocalization_radius: float
@@ -55,8 +53,6 @@ class PipelineConfiguration:
         """Create from a raw dictionary (typically loaded from YAML)."""
 
         return cls(
-            minimum_counts=int(data["minimum_counts"]),
-            maximum_counts_quantile=float(data["maximum_counts_quantile"]),
             minimum_cells=int(data["minimum_cells"]),
             pca_n_components=int(data["pca_n_components"]),
             neighborhood_colocalization_radius=float(

--- a/src/plotting.py
+++ b/src/plotting.py
@@ -12,8 +12,6 @@ import numpy as np
 import pandas as pd
 import scanpy as sc
 from anndata import AnnData
-from spatialdata import SpatialData
-import spatialdata_plot  # noqa: F401
 
 from .config import Configuration
 from .logging import get_logger
@@ -46,76 +44,6 @@ def _suppress_show() -> Iterator[None]:
         yield
     finally:
         plt.show = original_show
-
-
-def plot_cell_and_nucleus_boundaries(
-    configuration: Configuration,
-    spatial_data: SpatialData,
-) -> None:
-    """Plot cell and nucleus boundaries."""
-
-    out_path = configuration.figures_directory / "xenium_cell_nucleus_boundaries.png"
-    logger.debug("rendering cell and nucleus boundary plot to %s", out_path)
-
-    with _suppress_show():
-        fig, ax = plt.subplots(figsize=(14, 14), dpi=FIGURE_DPI)
-
-        (
-            spatial_data.pl.render_shapes(
-                element="cell_boundaries",
-                fill_alpha=0.0,
-                outline_color="#2d2d2d",
-                outline_width=0.2,
-                outline_alpha=1.0,
-            )
-            .pl.render_shapes(
-                element="nucleus_boundaries",
-                fill_alpha=0.0,
-                outline_color="#e64b35",
-                outline_width=0.35,
-                outline_alpha=1.0,
-            )
-            .pl.show(ax=ax, title="", dpi=FIGURE_DPI)
-        )
-
-        ax.axis("off")
-        fig.savefig(out_path, bbox_inches="tight", dpi=FIGURE_DPI)
-        plt.close(fig)
-        logger.debug("saved figure %s", out_path)
-
-
-def plot_transcripts(
-    configuration: Configuration,
-    spatial_data: SpatialData,
-    genes: list[str],
-    palette: list[str],
-    max_points: int = 50_000,
-) -> None:
-    """Plot transcripts."""
-
-    out_path = (
-        configuration.figures_directory / f"xenium_transcripts_{'_'.join(genes)}.png"
-    )
-    logger.debug("rendering transcript plot for genes=%s to %s", genes, out_path)
-
-    with _suppress_show():
-        fig, ax = plt.subplots(figsize=(14, 14), dpi=FIGURE_DPI)
-
-        (
-            spatial_data.pl.render_points(
-                element="transcripts",
-                color="feature_name",
-                groups=genes,
-                size=2,
-                max_points=max_points,
-                palette=palette,
-            ).pl.show(ax=ax, title="", dpi=FIGURE_DPI, colorbar=False)
-        )
-
-        ax.axis("off")
-        fig.savefig(out_path, bbox_inches="tight", dpi=FIGURE_DPI)
-        plt.close(fig)
-        logger.debug("saved figure %s", out_path)
 
 
 def plot_qc_histogram(
@@ -162,12 +90,11 @@ def plot_qc_histogram(
 
 def plot_umap_leiden(
     configuration: Configuration,
-    spatial_data: SpatialData,
+    annotated_data: AnnData,
 ) -> None:
-    """Plot UMAP colored by Leiden clusters."""
+    """Plot the composite UMAP colored by cell_type."""
 
     out_path = configuration.figures_directory / "umap_leiden.png"
-    annotated_data = spatial_data["table"]
     logger.debug("rendering UMAP plot to %s", out_path)
 
     with _suppress_show():
@@ -187,45 +114,159 @@ def plot_umap_leiden(
 
 def plot_cluster_overlay(
     configuration: Configuration,
-    spatial_data: SpatialData,
-    cluster_key: str = "cell_type",
+    annotated_data: AnnData,
+    cluster_key: str,
+    sample_id: str | None = None,
 ) -> None:
-    """Plot cell shapes colored by cluster labels (e.g. Leiden)."""
+    """Plot a per-sample centroid scatter colored by the given cluster label column."""
 
-    out_path = configuration.figures_directory / f"xenium_{cluster_key}_overlay.png"
+    if sample_id is not None:
+        if "sample_id" not in annotated_data.obs.columns:
+            raise ValueError(
+                f"sample_id={sample_id!r} requested but adata has no 'sample_id' column"
+            )
+        sample_mask = (
+            annotated_data.obs["sample_id"].astype(str) == sample_id
+        ).to_numpy()
+        if not sample_mask.any():
+            logger.warning(
+                "no cells found for sample_id=%r; skipping overlay", sample_id
+            )
+            return
+        view = annotated_data[sample_mask]
+    else:
+        view = annotated_data
+
+    # Build the cluster->color map from the full dataset so the same cluster keeps
+    # the same color across every per-sample plot.
+    all_categories = (
+        annotated_data.obs[cluster_key].dropna().astype("category").cat.categories
+    )
+    palette = _build_categorical_palette(len(all_categories))
+    color_map = dict(zip(all_categories, palette))
+
+    valid_mask = view.obs[cluster_key].notna().to_numpy()
+    coordinates = np.asarray(view.obsm["spatial"])[valid_mask]
+    cluster_values = view.obs[cluster_key].dropna()
+    if coordinates.size == 0:
+        logger.debug(
+            "skipping overlay for %s/%s: no labeled cells", cluster_key, sample_id
+        )
+        return
+
+    suffix = f"_{sample_id}" if sample_id is not None else ""
+    out_path = (
+        configuration.figures_directory / f"xenium_{cluster_key}_overlay{suffix}.png"
+    )
     logger.debug("rendering overlay for %s to %s", cluster_key, out_path)
-    table = spatial_data.tables["table"]
-    gdf = spatial_data.shapes["cell_boundaries"].copy()
-
-    cell_to_cluster = table.obs.set_index("cell_id")[cluster_key]
-    gdf[cluster_key] = gdf.index.map(cell_to_cluster)
-    gdf = gdf.dropna(subset=[cluster_key])
 
     with _suppress_show():
         fig, ax = plt.subplots(figsize=(14, 14), dpi=FIGURE_DPI)
-        n_clusters = max(gdf[cluster_key].nunique(), 1)
-        palette = _build_categorical_palette(n_clusters)
-        cmap = matplotlib.colors.ListedColormap(palette)
-        gdf.plot(
-            column=cluster_key,
-            ax=ax,
-            categorical=True,
-            legend=True,
-            edgecolor="gray",
-            linewidth=0.15,
-            cmap=cmap,
-            legend_kwds={
-                "loc": "center left",
-                "bbox_to_anchor": (1, 0.5),
-                "fontsize": 9,
-            },
-        )
+        for category in all_categories:
+            in_category = (cluster_values == category).to_numpy()
+            if not in_category.any():
+                continue
+            ax.scatter(
+                coordinates[in_category, 0],
+                coordinates[in_category, 1],
+                s=4,
+                color=color_map[category],
+                label=str(category),
+                alpha=0.85,
+                linewidths=0,
+            )
         ax.set_aspect("equal")
-        ax.axis("off")
         ax.invert_yaxis()
+        ax.set_xlabel("x")
+        ax.set_ylabel("y")
+        ax.set_title(f"{cluster_key}{' — ' + sample_id if sample_id else ''}")
+        ax.legend(
+            loc="center left",
+            bbox_to_anchor=(1.02, 0.5),
+            fontsize=9,
+            markerscale=2,
+            title=cluster_key,
+        )
+        fig.tight_layout()
         fig.savefig(out_path, bbox_inches="tight", dpi=FIGURE_DPI)
         plt.close(fig)
         logger.debug("saved figure %s", out_path)
+
+
+def plot_harmony_diagnostic(
+    configuration: Configuration,
+    annotated_data: AnnData,
+) -> None:
+    """Emit a side-by-side pre/post-Harmony UMAP colored by sample_id."""
+
+    if "X_umap_uncorrected" not in annotated_data.obsm:
+        logger.debug("skipping Harmony diagnostic: no uncorrected UMAP present")
+        return
+    if "sample_id" not in annotated_data.obs.columns:
+        logger.debug("skipping Harmony diagnostic: no sample_id column")
+        return
+
+    out_path = configuration.figures_directory / "harmony_umap_before_after.png"
+    logger.debug("rendering Harmony diagnostic to %s", out_path)
+
+    sample_categories = annotated_data.obs["sample_id"].astype("category")
+    palette = _build_categorical_palette(sample_categories.cat.categories.size)
+
+    with _suppress_show():
+        fig, axes = plt.subplots(1, 2, figsize=(16, 7), dpi=FIGURE_DPI)
+
+        _scatter_umap(
+            axes[0],
+            annotated_data.obsm["X_umap_uncorrected"],
+            sample_categories,
+            palette,
+            title="before Harmony",
+        )
+        _scatter_umap(
+            axes[1],
+            annotated_data.obsm["X_umap"],
+            sample_categories,
+            palette,
+            title="after Harmony",
+        )
+        axes[1].legend(
+            bbox_to_anchor=(1.02, 1),
+            loc="upper left",
+            fontsize=9,
+            markerscale=2,
+            title="sample_id",
+        )
+
+        fig.tight_layout()
+        fig.savefig(out_path, bbox_inches="tight", dpi=FIGURE_DPI)
+        plt.close(fig)
+        logger.debug("saved figure %s", out_path)
+
+
+def _scatter_umap(
+    axis: plt.Axes,
+    coordinates: np.ndarray,
+    categories: pd.Series,
+    palette: list[str],
+    title: str,
+) -> None:
+    """Scatter the given UMAP coordinates colored by the given categorical series."""
+
+    for color, category in zip(palette, categories.cat.categories):
+        mask = (categories == category).to_numpy()
+        axis.scatter(
+            coordinates[mask, 0],
+            coordinates[mask, 1],
+            s=3,
+            color=color,
+            label=str(category),
+            alpha=0.7,
+            linewidths=0,
+        )
+    axis.set_xlabel("UMAP 1")
+    axis.set_ylabel("UMAP 2")
+    axis.set_title(title)
+    axis.set_aspect("equal")
 
 
 def plot_rank_genes_dotplot(

--- a/src/preprocessing.py
+++ b/src/preprocessing.py
@@ -1,35 +1,47 @@
 from __future__ import annotations
 
 import numpy as np
+import pandas as pd
 import scanpy as sc
 from anndata import AnnData
+from scipy.stats import median_abs_deviation
 
 from .logging import get_logger
 
 logger = get_logger(__name__)
 
+_QC_METRICS = (
+    "log1p_total_counts",
+    "log1p_n_genes_by_counts",
+    "pct_counts_in_top_20_genes",
+)
+_MAD_THRESHOLD = 5.0
+
 
 def filter_cells_and_genes(
     annotated_data: AnnData,
-    minimum_counts: int,
-    maximum_counts_quantile: float,
     minimum_cells: int,
 ) -> None:
-    """Filter cells and genes based on the annotated data."""
+    """Flag per-sample MAD outliers, drop them, then apply the global gene filter."""
 
-    logger.debug(
-        "filtering cells and genes with minimum_counts=%s, maximum_counts_quantile=%s, minimum_cells=%s",
-        minimum_counts,
-        maximum_counts_quantile,
-        minimum_cells,
-    )
-    sc.pp.filter_cells(annotated_data, min_counts=minimum_counts)
-    sc.pp.filter_cells(
+    logger.debug("computing QC metrics for MAD outlier detection")
+    sc.pp.calculate_qc_metrics(
         annotated_data,
-        max_counts=int(
-            np.quantile(annotated_data.obs["total_counts"], maximum_counts_quantile)
-        ),
+        percent_top=[20],
+        log1p=True,
+        inplace=True,
     )
+
+    outlier_mask = _flag_per_sample_mad_outliers(annotated_data)
+    n_flagged = int(outlier_mask.sum())
+    logger.info(
+        "MAD outlier filter flagged %s cells at %s MADs across %s",
+        n_flagged,
+        _MAD_THRESHOLD,
+        ", ".join(_QC_METRICS),
+    )
+    annotated_data._inplace_subset_obs(~outlier_mask)
+
     sc.pp.filter_genes(annotated_data, min_cells=minimum_cells)
     logger.info(
         "QC retained %s cells and %s genes",
@@ -38,17 +50,48 @@ def filter_cells_and_genes(
     )
 
 
+def _flag_per_sample_mad_outliers(annotated_data: AnnData) -> np.ndarray:
+    """Return a boolean mask of cells flagged as outliers by 5-MAD per-sample QC."""
+
+    obs = annotated_data.obs
+    has_sample_id = "sample_id" in obs.columns
+    if has_sample_id:
+        grouping = obs["sample_id"].astype(str)
+    else:
+        grouping = pd.Series("__single__", index=obs.index)
+
+    outlier_mask = pd.Series(False, index=obs.index)
+    for metric in _QC_METRICS:
+        values = obs[metric]
+        grouped = values.groupby(grouping)
+        center = grouped.transform("median")
+        spread = grouped.transform(lambda group: median_abs_deviation(group.to_numpy()))
+        # When a sample's MAD is zero the metric is degenerate (bimodal cluster
+        # at the median, or a single cell). The 5-MAD band collapses to a point
+        # and any deviation becomes an "outlier", which over-flags. Treat the
+        # metric as uninformative for that sample instead.
+        has_spread = spread > 0
+        lower = center - _MAD_THRESHOLD * spread
+        upper = center + _MAD_THRESHOLD * spread
+        outlier_mask |= has_spread & ((values < lower) | (values > upper))
+
+    return outlier_mask.to_numpy()
+
+
 def normalize_and_scale(
     annotated_data: AnnData,
 ) -> None:
-    """Normalize and scale the annotated data."""
+    """Normalize and scale the annotated data, picking HVGs with batch awareness when applicable."""
 
     logger.debug("normalizing and scaling %s cells", annotated_data.n_obs)
-    sc.pp.highly_variable_genes(
-        annotated_data,
-        flavor="seurat_v3",
-        n_top_genes=2000,
-    )
+    hvg_kwargs = {"flavor": "seurat_v3", "n_top_genes": 2000}
+    if (
+        "sample_id" in annotated_data.obs.columns
+        and annotated_data.obs["sample_id"].nunique() > 1
+    ):
+        hvg_kwargs["batch_key"] = "sample_id"
+    sc.pp.highly_variable_genes(annotated_data, **hvg_kwargs)
+
     sc.pp.normalize_total(annotated_data)
     sc.pp.log1p(annotated_data)
     annotated_data.layers["log_normalized"] = annotated_data.X.copy()

--- a/src/state.py
+++ b/src/state.py
@@ -31,8 +31,6 @@ def configuration_settings_snapshot(configuration: Configuration) -> dict[str, A
         "logs_directory": str(configuration.logs_directory),
         "annotation_model": configuration.annotation_model,
         "pipeline": {
-            "minimum_counts": pipeline.minimum_counts,
-            "maximum_counts_quantile": pipeline.maximum_counts_quantile,
             "minimum_cells": pipeline.minimum_cells,
             "pca_n_components": pipeline.pca_n_components,
             "neighborhood_colocalization_radius": (

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -47,8 +47,6 @@ def configuration(tmp_path: Path) -> Configuration:
         logs_directory=tmp_path / "output" / "logs",
         annotation_model="llama3.1:8b",
         pipeline=PipelineConfiguration(
-            minimum_counts=5,
-            maximum_counts_quantile=0.99,
             minimum_cells=2,
             pca_n_components=5,
             neighborhood_colocalization_radius=25.0,

--- a/tests/test_analysis.py
+++ b/tests/test_analysis.py
@@ -1,11 +1,16 @@
 from __future__ import annotations
 
+from unittest.mock import patch
+
+import anndata as ad
 import numpy as np
 import scanpy as sc
 from anndata import AnnData
 
 from src import analysis
 from src.preprocessing import normalize_and_scale
+
+from .conftest import build_synthetic_adata
 
 
 def _prepare_for_clustering(adata: AnnData) -> None:
@@ -15,26 +20,49 @@ def _prepare_for_clustering(adata: AnnData) -> None:
     normalize_and_scale(adata)
 
 
-def test_run_clustering_adds_pca_and_leiden(tiny_adata: AnnData) -> None:
-    """run_clustering populates X_pca and a leiden obs column with multiple groups."""
+def test_run_clustering_single_sample_skips_harmony(tiny_adata: AnnData) -> None:
+    """Single-sample run populates X_pca, X_umap, leiden but not X_pca_harmony."""
 
     _prepare_for_clustering(tiny_adata)
     analysis.run_clustering(tiny_adata, pca_n_components=5)
 
     assert "X_pca" in tiny_adata.obsm
-    assert tiny_adata.obsm["X_pca"].shape == (tiny_adata.n_obs, 5)
+    assert "X_pca_harmony" not in tiny_adata.obsm
+    assert "X_umap_uncorrected" not in tiny_adata.obsm
+    assert tiny_adata.obsm["X_umap"].shape == (tiny_adata.n_obs, 2)
     assert "leiden" in tiny_adata.obs.columns
     assert tiny_adata.obs["leiden"].nunique() >= 2
 
 
-def test_run_umap_adds_two_dimensional_embedding(tiny_adata: AnnData) -> None:
-    """run_umap attaches a 2-D X_umap embedding to obsm."""
+def test_run_clustering_multi_sample_runs_harmony_and_stores_uncorrected_umap() -> None:
+    """Multi-sample run writes X_pca_harmony, X_umap_uncorrected, and canonical X_umap."""
 
-    _prepare_for_clustering(tiny_adata)
-    analysis.run_clustering(tiny_adata, pca_n_components=5)
-    analysis.run_umap(tiny_adata)
+    sample_a = build_synthetic_adata(seed=0)
+    sample_b = build_synthetic_adata(seed=1)
+    merged = ad.concat(
+        [sample_a, sample_b],
+        keys=["sample_a", "sample_b"],
+        label="sample_id",
+        index_unique="_",
+    )
+    merged.obs.index.name = None
+    _prepare_for_clustering(merged)
 
-    assert tiny_adata.obsm["X_umap"].shape == (tiny_adata.n_obs, 2)
+    def fake_harmony(adata, key):
+        adata.obsm["X_pca_harmony"] = adata.obsm["X_pca"].copy()
+
+    with patch(
+        "src.analysis.sce.pp.harmony_integrate", side_effect=fake_harmony
+    ) as mocked:
+        analysis.run_clustering(merged, pca_n_components=5)
+
+    mocked.assert_called_once()
+    assert mocked.call_args.kwargs["key"] == "sample_id"
+    assert "X_pca_harmony" in merged.obsm
+    assert "X_umap_uncorrected" in merged.obsm
+    assert "X_umap" in merged.obsm
+    assert merged.obsm["X_umap"].shape == (merged.n_obs, 2)
+    assert "leiden" in merged.obs.columns
 
 
 def test_rank_genes_populates_uns(tiny_adata: AnnData) -> None:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -14,8 +14,6 @@ def _base_config_dict(raw: Path, output: Path) -> dict:
         "output_directory": str(output),
         "annotation_model": "llama3.1:8b",
         "pipeline": {
-            "minimum_counts": 10,
-            "maximum_counts_quantile": 0.99,
             "minimum_cells": 5,
             "pca_n_components": 20,
             "neighborhood_colocalization_radius": 50.0,
@@ -141,8 +139,6 @@ def test_pipeline_configuration_casts_numeric_types() -> None:
     """PipelineConfiguration.from_dictionary coerces numeric strings to int/float."""
 
     raw = {
-        "minimum_counts": "100",
-        "maximum_counts_quantile": "0.99",
         "minimum_cells": "5",
         "pca_n_components": "20",
         "neighborhood_colocalization_radius": "50.0",
@@ -155,7 +151,7 @@ def test_pipeline_configuration_casts_numeric_types() -> None:
     }
     pipeline = PipelineConfiguration.from_dictionary(raw)
 
-    assert pipeline.minimum_counts == 100
-    assert pipeline.maximum_counts_quantile == pytest.approx(0.99)
+    assert pipeline.minimum_cells == 5
     assert pipeline.pca_n_components == 20
+    assert pipeline.neighborhood_colocalization_radius == pytest.approx(50.0)
     assert pipeline.colocalization_number_of_permutations == 200

--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -28,8 +28,6 @@ def multi_sample_configuration(tmp_path: Path) -> Configuration:
         figures_directory=tmp_path / "output" / "figures",
         logs_directory=tmp_path / "output" / "logs",
         pipeline=PipelineConfiguration(
-            minimum_counts=1,
-            maximum_counts_quantile=0.99,
             minimum_cells=1,
             pca_n_components=2,
             neighborhood_colocalization_radius=1.0,

--- a/tests/test_plotting.py
+++ b/tests/test_plotting.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import numpy as np
 import scanpy as sc
 from anndata import AnnData
 
@@ -15,21 +16,152 @@ def _assert_nonempty_file(path) -> None:
     assert path.stat().st_size > 0, f"figure at {path} is empty"
 
 
-def test_plot_qc_histogram_writes_figure(
+def test_plot_cluster_overlay_writes_per_sample_centroid_scatter(
     configuration: Configuration,
     tiny_adata: AnnData,
 ) -> None:
-    """plot_qc_histogram writes the transcripts-per-cell histogram PNG."""
+    """plot_cluster_overlay emits a per-sample PNG using obsm['spatial']."""
 
-    plotting.plot_qc_histogram(
+    tiny_adata.obs["sample_id"] = ["sample_a"] * tiny_adata.n_obs
+
+    plotting.plot_cluster_overlay(
         configuration,
         tiny_adata,
-        cutoffs=[1, 0.99],
-        cutoff_colors=["crimson", "goldenrod"],
+        cluster_key="cell_type",
+        sample_id="sample_a",
+    )
+    _assert_nonempty_file(
+        configuration.figures_directory / "xenium_cell_type_overlay_sample_a.png"
     )
 
-    output_path = configuration.figures_directory / "xenium_transcripts_per_cell.png"
-    _assert_nonempty_file(output_path)
+
+def test_plot_cluster_overlay_filters_to_requested_sample(
+    configuration: Configuration,
+    tiny_adata: AnnData,
+) -> None:
+    """A sample_id with no matching cells produces no file (and no crash)."""
+
+    tiny_adata.obs["sample_id"] = ["sample_a"] * tiny_adata.n_obs
+
+    plotting.plot_cluster_overlay(
+        configuration,
+        tiny_adata,
+        cluster_key="cell_type",
+        sample_id="missing_sample",
+    )
+    assert not (
+        configuration.figures_directory / "xenium_cell_type_overlay_missing_sample.png"
+    ).exists()
+
+
+def test_plot_cluster_overlay_raises_when_sample_id_column_missing(
+    configuration: Configuration,
+    tiny_adata: AnnData,
+) -> None:
+    """Requesting a sample_id when the column is absent raises rather than mislabeling output."""
+
+    import pytest
+
+    assert "sample_id" not in tiny_adata.obs.columns
+    with pytest.raises(ValueError, match="no 'sample_id' column"):
+        plotting.plot_cluster_overlay(
+            configuration,
+            tiny_adata,
+            cluster_key="cell_type",
+            sample_id="patient_001",
+        )
+
+
+def test_plot_cluster_overlay_uses_global_palette_size(
+    configuration: Configuration,
+    tiny_adata: AnnData,
+) -> None:
+    """Per-sample plots derive their palette from the full dataset's categories."""
+
+    from unittest.mock import patch
+
+    import anndata as ad
+
+    # Build a merged adata where each sample has a strict subset of categories
+    # to make per-sample category-set != full category-set.
+    sample_a = tiny_adata[tiny_adata.obs["cell_type"].astype(str) != "type_2"].copy()
+    sample_b = tiny_adata[tiny_adata.obs["cell_type"].astype(str) != "type_0"].copy()
+    merged = ad.concat(
+        [sample_a, sample_b],
+        keys=["sample_a", "sample_b"],
+        label="sample_id",
+        index_unique="_",
+    )
+    merged.obs.index.name = None
+    full_category_count = merged.obs["cell_type"].astype(str).nunique()
+
+    palette_call_sizes: list[int] = []
+    real_builder = plotting._build_categorical_palette
+
+    def recording_builder(n_categories: int) -> list[str]:
+        palette_call_sizes.append(n_categories)
+        return real_builder(n_categories)
+
+    with patch.object(
+        plotting, "_build_categorical_palette", side_effect=recording_builder
+    ):
+        plotting.plot_cluster_overlay(
+            configuration, merged, cluster_key="cell_type", sample_id="sample_a"
+        )
+        plotting.plot_cluster_overlay(
+            configuration, merged, cluster_key="cell_type", sample_id="sample_b"
+        )
+
+    assert palette_call_sizes == [full_category_count, full_category_count]
+
+
+def test_plot_umap_leiden_takes_anndata_directly(
+    configuration: Configuration,
+    tiny_adata: AnnData,
+) -> None:
+    """plot_umap_leiden writes a UMAP PNG when given an AnnData with cell_type and X_umap."""
+
+    sc.pp.calculate_qc_metrics(tiny_adata, inplace=True, percent_top=None, log1p=False)
+    normalize_and_scale(tiny_adata)
+    analysis.run_clustering(tiny_adata, pca_n_components=5)
+    tiny_adata.obs["cell_type"] = tiny_adata.obs["leiden"].astype(str)
+
+    plotting.plot_umap_leiden(configuration, tiny_adata)
+    _assert_nonempty_file(configuration.figures_directory / "umap_leiden.png")
+
+
+def test_plot_harmony_diagnostic_writes_figure(
+    configuration: Configuration,
+    tiny_adata: AnnData,
+) -> None:
+    """plot_harmony_diagnostic writes a side-by-side pre/post UMAP composite."""
+
+    tiny_adata.obs["sample_id"] = ["sample_a"] * (tiny_adata.n_obs // 2) + [
+        "sample_b"
+    ] * (tiny_adata.n_obs - tiny_adata.n_obs // 2)
+    tiny_adata.obsm["X_umap_uncorrected"] = np.random.default_rng(0).normal(
+        size=(tiny_adata.n_obs, 2)
+    )
+    tiny_adata.obsm["X_umap"] = np.random.default_rng(1).normal(
+        size=(tiny_adata.n_obs, 2)
+    )
+
+    plotting.plot_harmony_diagnostic(configuration, tiny_adata)
+    _assert_nonempty_file(
+        configuration.figures_directory / "harmony_umap_before_after.png"
+    )
+
+
+def test_plot_harmony_diagnostic_skips_when_no_uncorrected_umap(
+    configuration: Configuration,
+    tiny_adata: AnnData,
+) -> None:
+    """The diagnostic is a no-op when the uncorrected UMAP is absent (single-sample run)."""
+
+    plotting.plot_harmony_diagnostic(configuration, tiny_adata)
+    assert not (
+        configuration.figures_directory / "harmony_umap_before_after.png"
+    ).exists()
 
 
 def test_plot_rank_genes_dotplot_writes_figure(

--- a/tests/test_preprocessing.py
+++ b/tests/test_preprocessing.py
@@ -1,66 +1,127 @@
 from __future__ import annotations
 
-import numpy as np
-import pandas as pd
 import scanpy as sc
 from anndata import AnnData
+from scipy.sparse import csr_matrix
 
 from src.preprocessing import filter_cells_and_genes, normalize_and_scale
 
+from .conftest import build_synthetic_adata
 
-def test_filter_cells_removes_cells_below_min_counts(tiny_adata: AnnData) -> None:
-    """filter_cells_and_genes drops cells whose total_counts falls below min_counts."""
 
-    sc.pp.calculate_qc_metrics(tiny_adata, inplace=True, percent_top=None, log1p=False)
-    target_threshold = int(tiny_adata.obs["total_counts"].quantile(0.5))
-    n_before = tiny_adata.n_obs
+def _concat_with_sample_ids(
+    adatas: list[AnnData],
+    sample_ids: list[str],
+) -> AnnData:
+    """Helper: concat per-sample AnnDatas with a sample_id column and unique obs_names."""
 
-    filter_cells_and_genes(
-        tiny_adata,
-        minimum_counts=target_threshold,
-        maximum_counts_quantile=1.0,
-        minimum_cells=1,
+    import anndata as ad
+
+    merged = ad.concat(
+        adatas,
+        keys=sample_ids,
+        label="sample_id",
+        index_unique="_",
     )
+    merged.obs.index.name = None
+    return merged
 
-    assert tiny_adata.n_obs < n_before
-    assert (tiny_adata.obs["total_counts"] >= target_threshold).all()
+
+def test_filter_cells_and_genes_drops_extreme_outliers_single_sample(
+    tiny_adata: AnnData,
+) -> None:
+    """A cell with wildly inflated counts is flagged as a MAD outlier and dropped."""
+
+    original_obs = tiny_adata.obs.index[0]
+    extreme_row = tiny_adata.X.toarray().copy()
+    extreme_row[0] = extreme_row[0] * 1000
+    tiny_adata.X = csr_matrix(extreme_row)
+
+    filter_cells_and_genes(tiny_adata, minimum_cells=1)
+
+    assert original_obs not in tiny_adata.obs.index
 
 
-def test_filter_genes_removes_genes_below_min_cells() -> None:
-    """filter_cells_and_genes drops genes expressed in fewer cells than min_cells."""
+def test_filter_cells_and_genes_applies_mad_per_sample(
+    tiny_adata: AnnData,
+) -> None:
+    """Per-sample MAD filtering derives different cutoffs when samples have different scales."""
 
-    counts = np.zeros((20, 5), dtype=np.float32)
-    counts[:, 0] = 10.0
-    counts[:10, 1] = 5.0
-    counts[:2, 2] = 1.0
-
-    obs = pd.DataFrame(
-        {
-            "total_counts": counts.sum(axis=1),
-            "cell_id": [f"c{i}" for i in range(20)],
-        },
-        index=[f"c{i}" for i in range(20)],
+    dense = tiny_adata.X.toarray()
+    sample_a = AnnData(
+        X=csr_matrix(dense),
+        obs=tiny_adata.obs.copy(),
+        var=tiny_adata.var.copy(),
     )
-    var = pd.DataFrame(index=pd.Index([f"g{i}" for i in range(5)], name="gene_id"))
-    adata = AnnData(X=counts, obs=obs, var=var)
-    sc.pp.calculate_qc_metrics(adata, inplace=True, percent_top=None, log1p=False)
+    sample_a.obsm["spatial"] = tiny_adata.obsm["spatial"].copy()
+    sample_a.layers["counts"] = sample_a.X.copy()
 
-    filter_cells_and_genes(
-        adata,
-        minimum_counts=1,
-        maximum_counts_quantile=1.0,
-        minimum_cells=5,
+    sample_b = AnnData(
+        X=csr_matrix(dense * 10),
+        obs=tiny_adata.obs.copy(),
+        var=tiny_adata.var.copy(),
     )
+    sample_b.obsm["spatial"] = tiny_adata.obsm["spatial"].copy()
+    sample_b.layers["counts"] = sample_b.X.copy()
 
-    assert set(adata.var_names) == {"g0", "g1"}
+    merged = _concat_with_sample_ids([sample_a, sample_b], ["sample_a", "sample_b"])
+
+    filter_cells_and_genes(merged, minimum_cells=1)
+
+    sample_b_rows = merged[merged.obs["sample_id"].astype(str) == "sample_b"]
+    assert sample_b_rows.n_obs > 0
 
 
-def test_normalize_and_scale_sets_expected_anndata_state(tiny_adata: AnnData) -> None:
-    """normalize_and_scale computes HVGs, writes log_normalized layer, and scales X."""
+def test_filter_cells_and_genes_applies_global_gene_filter(tiny_adata: AnnData) -> None:
+    """The global min_cells gene filter drops genes below the minimum cell count."""
+
+    dense = tiny_adata.X.toarray()
+    dense[:, -1] = 0
+    dense[0, -1] = 1
+    tiny_adata.X = csr_matrix(dense)
+    rare_gene = tiny_adata.var_names[-1]
+
+    filter_cells_and_genes(tiny_adata, minimum_cells=10)
+
+    assert rare_gene not in tiny_adata.var_names
+
+
+def test_filter_cells_and_genes_skips_zero_spread_metric(tiny_adata: AnnData) -> None:
+    """When a sample's MAD collapses to zero on a metric, no cells are flagged on that metric."""
+
+    from src.preprocessing import _flag_per_sample_mad_outliers
+
+    sc.pp.calculate_qc_metrics(tiny_adata, inplace=True, percent_top=[20], log1p=True)
+
+    # Force one metric to be constant across every cell: MAD on that metric
+    # collapses to zero, so the 5-MAD band has no width.
+    tiny_adata.obs["pct_counts_in_top_20_genes"] = 50.0
+
+    mask = _flag_per_sample_mad_outliers(tiny_adata)
+    # Only the two remaining metrics drive flagging; the constant one must not
+    # drag every cell into the outlier set.
+    assert mask.sum() < tiny_adata.n_obs
+
+
+def test_normalize_and_scale_single_sample_hvg(tiny_adata: AnnData) -> None:
+    """Single-sample run does not add the highly_variable_nbatches column."""
 
     sc.pp.calculate_qc_metrics(tiny_adata, inplace=True, percent_top=None, log1p=False)
     normalize_and_scale(tiny_adata)
 
     assert "highly_variable" in tiny_adata.var.columns
+    assert "highly_variable_nbatches" not in tiny_adata.var.columns
     assert "log_normalized" in tiny_adata.layers
-    assert tiny_adata.X.max() <= 10.0 + 1e-6
+
+
+def test_normalize_and_scale_multi_sample_uses_batch_key() -> None:
+    """Multi-sample HVG selection adds the highly_variable_nbatches column."""
+
+    sample_a = build_synthetic_adata(seed=0)
+    sample_b = build_synthetic_adata(seed=1)
+    merged = _concat_with_sample_ids([sample_a, sample_b], ["sample_a", "sample_b"])
+
+    sc.pp.calculate_qc_metrics(merged, inplace=True, percent_top=None, log1p=False)
+    normalize_and_scale(merged)
+
+    assert "highly_variable_nbatches" in merged.var.columns

--- a/uv.lock
+++ b/uv.lock
@@ -327,6 +327,7 @@ name = "code"
 version = "0.1.0"
 source = { virtual = "." }
 dependencies = [
+    { name = "harmonypy" },
     { name = "igraph" },
     { name = "scanpy" },
     { name = "scikit-misc" },
@@ -345,6 +346,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "harmonypy", specifier = "==0.0.10" },
     { name = "igraph", specifier = ">=1.0.0" },
     { name = "scanpy", specifier = ">=1.11,<1.12" },
     { name = "scikit-misc", specifier = ">=0.5.2" },
@@ -800,6 +802,21 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/d3/39/a7ef948ddf4d1c556b0b2b9559534777bccc318543b3f5a1efdf6b556c9c/h5py-3.15.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:99d374a21f7321a4c6ab327c4ab23bd925ad69821aeb53a1e75dd809d19f67fa", size = 5025426, upload-time = "2025-10-16T10:35:19.831Z" },
     { url = "https://files.pythonhosted.org/packages/b6/d8/7368679b8df6925b8415f9dcc9ab1dab01ddc384d2b2c24aac9191bd9ceb/h5py-3.15.1-cp314-cp314-win_amd64.whl", hash = "sha256:9c73d1d7cdb97d5b17ae385153472ce118bed607e43be11e9a9deefaa54e0734", size = 2865704, upload-time = "2025-10-16T10:35:22.658Z" },
     { url = "https://files.pythonhosted.org/packages/d3/b7/4a806f85d62c20157e62e58e03b27513dc9c55499768530acc4f4c5ce4be/h5py-3.15.1-cp314-cp314-win_arm64.whl", hash = "sha256:a6d8c5a05a76aca9a494b4c53ce8a9c29023b7f64f625c6ce1841e92a362ccdf", size = 2465544, upload-time = "2025-10-16T10:35:25.695Z" },
+]
+
+[[package]]
+name = "harmonypy"
+version = "0.0.10"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+    { name = "pandas" },
+    { name = "scikit-learn" },
+    { name = "scipy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1a/69/9af6183745618057797b940a76320c52a38ad2a69e688e6345e2a0219655/harmonypy-0.0.10.tar.gz", hash = "sha256:27bd39a6f9ada1708ffa577e46c9b7363d1e2fd62740e477ce11fd61819a54df", size = 20339, upload-time = "2024-07-04T20:55:06.385Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cc/cd/9479dd66e503af191edc016a302d2125c4f02ea777ebea1e48f6b944b073/harmonypy-0.0.10-py3-none-any.whl", hash = "sha256:dab528052f909204e521c9c2bd980221c64003538b0c0fe25be2e43c1199282b", size = 20885, upload-time = "2024-07-04T20:55:00.329Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
> Stacks on #17 (multi-sample AnnData ingest). GitHub will reflect only this PR's diff once #17 merges.

## Summary

Rewires the non-spatial analysis stack for multi-sample correctness and lands Harmony batch correction. Per-sample 5-MAD QC replaces the global `min_counts` / `max_counts_quantile` cell filter; HVG selection becomes batch-aware; `run_clustering` branches on sample count and, when `n_samples > 1`, computes an uncorrected UMAP for the diagnostic, runs `sce.pp.harmony_integrate(key=\"sample_id\")`, then rebuilds neighbors on the corrected embedding before Leiden. Also restores `plot_umap_leiden` and rewrites `plot_cluster_overlay` as a centroid scatter that iterates per sample with consistent per-cluster colors.

## Changes

- **QC (MAD-based, per-sample).** `filter_cells_and_genes` now runs `sc.pp.calculate_qc_metrics(percent_top=[20], log1p=True)` and flags outliers at 5 MADs on `log1p_total_counts`, `log1p_n_genes_by_counts`, and `pct_counts_in_top_20_genes`, grouped by `sample_id`. Zero-spread sample groups skip that metric to avoid collapsing the band to a point and over-flagging. Global `sc.pp.filter_genes(min_cells=...)` runs post-concat.
- **HVG.** `normalize_and_scale` passes `batch_key=\"sample_id\"` to `sc.pp.highly_variable_genes(flavor=\"seurat_v3\", n_top_genes=2000, ...)` only when the adata has multiple samples.
- **Harmony.** `run_clustering` branches:
  - `n_samples == 1`: PCA → neighbors(use_rep=\"X_pca\") → UMAP → Leiden (existing behavior preserved).
  - `n_samples > 1`: PCA → neighbors → UMAP, copy to `obsm[\"X_umap_uncorrected\"]` → `sce.pp.harmony_integrate(key=\"sample_id\")` → neighbors(use_rep=\"X_pca_harmony\") → UMAP → Leiden.
  - Code comment documents that `sample_id` is the only valid batch key.
- **Diagnostic plot.** New `plot_harmony_diagnostic` emits a side-by-side pre/post UMAP colored by `sample_id` as `figures/harmony_umap_before_after.png`. No-op on single-sample runs.
- **Restored plots.** `plot_umap_leiden` now takes AnnData directly. `plot_cluster_overlay` rewritten as a centroid scatter on `obsm[\"spatial\"]` with an optional `sample_id` parameter. Per-sample filenames include the sample id. Cluster-to-color map is derived from the **full** adata's categories so the same cluster keeps the same color across every per-sample plot.
- **Dropped plots.** `plot_cell_and_nucleus_boundaries` and `plot_transcripts` removed — they required SpatialData shapes and points that the AnnData pipeline artifact no longer carries.
- **Config slimming.** `minimum_counts` and `maximum_counts_quantile` removed from `PipelineConfiguration`, `config.yaml`, and `state.configuration_settings_snapshot`. Only `minimum_cells` (the gene filter) remains.
- **harmonypy pin.** `pyproject.toml` pins `harmonypy==0.0.10`. Scanpy 1.11.5's `harmony_integrate` assumes the old `(n_components, n_cells)` `Z_corr` shape; the 0.2.x PyTorch rewrite returns `(n_cells, n_components)`, causing a shape mismatch when assigning to `obsm[\"X_pca_harmony\"]`. 10X Genomics pins the same version in their Xenium integration notebook.
- **Labeling hazards guarded.** `plot_cluster_overlay` raises `ValueError` if `sample_id` is requested but the column doesn't exist (no silent mislabeling), and warns+no-ops when the requested sample has no cells.

## Testing

```bash
uv run pytest
# 70 passed
```

End-to-end verified by running on the real two-sample `region_2` + `region_3` config (360K cells); the bug this PR fixes (the shape mismatch from the wrong harmonypy version) is why the pinning is part of the PR rather than a follow-up.

New and extended tests:
- `tests/test_preprocessing.py`: MAD filter drops inflated cells; per-sample MAD applied groupby `sample_id`; zero-spread metric is skipped; HVG `batch_key` threads through when multi-sample; `highly_variable_nbatches` appears in that case.
- `tests/test_analysis.py`: single-sample run doesn't populate `X_pca_harmony` / `X_umap_uncorrected`; multi-sample run does. Harmony mocked at the `sce.pp.harmony_integrate` boundary.
- `tests/test_plotting.py`: Harmony diagnostic PNG written on multi-sample; no-op on single-sample; per-sample overlay emits a sample-suffixed PNG; missing `sample_id` column raises; palette sized from the full dataset's categories (verified by mocking `_build_categorical_palette`).

## Closes

Closes #15.